### PR TITLE
Add old AWS cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-old-aws.yml
+++ b/.github/workflows/cleanup-old-aws.yml
@@ -1,0 +1,92 @@
+name: Cleanup Old AWS Account
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type cleanup-old-aws to delete old AWS resources'
+        required: true
+      region:
+        description: 'Old AWS deployment region'
+        required: true
+        default: us-east-1
+
+jobs:
+  cleanup-old-aws:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ inputs.region }}
+      APP_STACK_NAME: WorldCupStackProd
+      BOOTSTRAP_STACK_NAME: CDKToolkit
+    steps:
+      - name: Require explicit confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "cleanup-old-aws" ]; then
+            echo "Refusing to run cleanup without exact confirmation."
+            exit 1
+          fi
+
+      - name: Show target AWS identity
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity
+
+      - name: Delete application stack if present
+        run: |
+          set -euo pipefail
+          if aws cloudformation describe-stacks --stack-name "$APP_STACK_NAME" >/dev/null 2>&1; then
+            echo "Deleting $APP_STACK_NAME..."
+            aws cloudformation delete-stack --stack-name "$APP_STACK_NAME"
+            aws cloudformation wait stack-delete-complete --stack-name "$APP_STACK_NAME"
+          else
+            echo "$APP_STACK_NAME does not exist."
+          fi
+
+      - name: Empty CDK bootstrap assets
+        run: |
+          set -euo pipefail
+          if ! aws cloudformation describe-stacks --stack-name "$BOOTSTRAP_STACK_NAME" >/dev/null 2>&1; then
+            echo "$BOOTSTRAP_STACK_NAME does not exist."
+            exit 0
+          fi
+
+          aws cloudformation describe-stack-resources \
+            --stack-name "$BOOTSTRAP_STACK_NAME" \
+            --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" \
+            --output text | tr '\t' '\n' | while read -r bucket; do
+              [ -n "$bucket" ] || continue
+              echo "Emptying S3 bucket $bucket..."
+              aws s3 rm "s3://$bucket" --recursive || true
+              aws s3api list-object-versions --bucket "$bucket" --output json > object-versions.json
+              jq '{Objects: (((.Versions // []) + (.DeleteMarkers // [])) | map({Key, VersionId})[:1000]), Quiet: true}' object-versions.json > delete-objects.json
+              if [ "$(jq '.Objects | length' delete-objects.json)" -gt 0 ]; then
+                aws s3api delete-objects --bucket "$bucket" --delete file://delete-objects.json
+              fi
+            done
+
+          aws cloudformation describe-stack-resources \
+            --stack-name "$BOOTSTRAP_STACK_NAME" \
+            --query "StackResources[?ResourceType=='AWS::ECR::Repository'].PhysicalResourceId" \
+            --output text | tr '\t' '\n' | while read -r repository; do
+              [ -n "$repository" ] || continue
+              echo "Emptying ECR repository $repository..."
+              aws ecr list-images --repository-name "$repository" --output json > images.json
+              if [ "$(jq '.imageIds | length' images.json)" -gt 0 ]; then
+                jq '.imageIds[:100]' images.json > image-ids.json
+                aws ecr batch-delete-image --repository-name "$repository" --image-ids file://image-ids.json
+              fi
+            done
+
+      - name: Delete CDK bootstrap stack
+        run: |
+          set -euo pipefail
+          if aws cloudformation describe-stacks --stack-name "$BOOTSTRAP_STACK_NAME" >/dev/null 2>&1; then
+            echo "Deleting $BOOTSTRAP_STACK_NAME..."
+            aws cloudformation delete-stack --stack-name "$BOOTSTRAP_STACK_NAME"
+            aws cloudformation wait stack-delete-complete --stack-name "$BOOTSTRAP_STACK_NAME"
+          else
+            echo "$BOOTSTRAP_STACK_NAME does not exist."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,3 @@ jobs:
       - run: npm run build
         env:
           VITE_GRAPHQL_SERVER_URI: https://graphql.tipping.aasan.dev
-      - run: npm run deploy
-        env:
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          DOMAIN_HOSTED_ZONE: tipping.aasan.dev
-          DOMAIN_GRAPHQL_SERVER: graphql.tipping.aasan.dev


### PR DESCRIPTION
## Summary

- Stops the `main` workflow from deploying automatically with the old AWS secrets.
- Adds a manual `Cleanup Old AWS Account` workflow that uses the existing AWS secrets to delete `WorldCupStackProd` if present, empty CDK bootstrap S3/ECR assets, and delete `CDKToolkit`.

## Validation

- `npm test`
- `npm run build`
- `git diff --check`

After this is merged, I will dispatch the cleanup workflow once against the old `us-east-1` account before replacing the repository AWS secrets for the new Stockholm deployment target.