### PR TITLE
Bundle backend Lambda dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^24.13.2",
+        "esbuild": "^0.28.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-node": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^24.13.2",
+    "esbuild": "^0.28.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-node": "^0.4.0",

--- a/packages/cdk/src/cdk-stack.ts
+++ b/packages/cdk/src/cdk-stack.ts
@@ -1,5 +1,6 @@
 import { App, Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
-import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import {
   Certificate,
@@ -28,12 +29,12 @@ export class WorldCupStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const graphQLServerFunction = new Function(
+    const graphQLServerFunction = new NodejsFunction(
       this,
       'graphql-server-function',
       {
-        code: Code.fromAsset(path.join(__dirname, '../../backend')),
-        handler: 'build/index.handler',
+        entry: path.join(__dirname, '../../backend/src/index.ts'),
+        handler: 'handler',
         runtime: Runtime.NODEJS_24_X,
         timeout: Duration.seconds(30),
         memorySize: 1024,


### PR DESCRIPTION
## Summary
- switch the GraphQL Lambda to CDK NodejsFunction bundling
- add esbuild explicitly for Lambda bundling

## Why
The first Stockholm deploy succeeded, but API Gateway returned 502 because Lambda failed with `Runtime.ImportModuleError: Cannot find module @apollo/server`. Bundling the backend entrypoint includes runtime dependencies in the Lambda asset.

## Test plan
- npm test
- npm run build
- cdk synth with production env vars