### PR TITLE
[codex] Migrate tipping app to World Cup 2026

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,13 @@ jobs:
       DOMAIN_GRAPHQL_SERVER: graphql.tipping.aasan.dev
       DOMAIN_HOSTED_ZONE: tipping.aasan.dev
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+      GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY }}
+      GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+      GOOGLE_OAUTH_REFRESH_TOKEN: ${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}
+      GOOGLE_SHEETS_ID: 1hsMSMhqu4UTrPlToYrfxjFrIXmT2JaiVzzjXeUvbgpw
+      GOOGLE_SHEETS_RANGE: "'Form Responses 1'!A1:CS125"
       VITE_GRAPHQL_SERVER_URI: https://graphql.tipping.aasan.dev
     steps:
       - uses: actions/checkout@v6.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
 # tipping.aasan.dev
 
 https://tipping.aasan.dev
+
+## 2026 data source
+
+The backend defaults to the 2026 response sheet:
+
+- Spreadsheet: `1hsMSMhqu4UTrPlToYrfxjFrIXmT2JaiVzzjXeUvbgpw`
+- Range: `'Form Responses 1'!A1:CS125`
+
+Override these with `GOOGLE_SHEETS_ID` and `GOOGLE_SHEETS_RANGE` if the sheet
+layout changes.
+
+### AWS access to the sheet
+
+For a private Google Sheet in AWS, configure the Lambda with Google credentials.
+Preferred: use a Google service account that has viewer access to the response
+sheet:
+
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+- `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+The private key may contain escaped newlines (`\n`).
+
+Alternative: use OAuth refresh credentials from a valid Google OAuth client:
+
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+- `GOOGLE_OAUTH_REFRESH_TOKEN`
+
+If neither authenticated path is set, the backend falls back to
+`GOOGLE_API_KEY`, which only works when the sheet is readable by that API key.
+
+### Fasit row
+
+The app no longer assumes the last row is the fasit row. To enter results in the
+sheet, add one row anywhere in the response range with `fasit` or `blueprint` in
+one of the first three cells. The remaining cells in that row are matched to the
+same question columns as the user responses.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "NODE_ENV=development DEBUG=google tsx watch ./src/server/server-local.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run src --coverage=false"
   },
   "dependencies": {
     "@apollo/datasource-rest": "^6.4.1",

--- a/packages/backend/src/data-sources/google/GoogleAPI.ts
+++ b/packages/backend/src/data-sources/google/GoogleAPI.ts
@@ -23,7 +23,14 @@ const GOOGLE_SHEETS_ID =
 const GOOGLE_SHEETS_RANGE =
   getOptionalEnvVar('GOOGLE_SHEETS_RANGE') || "'Form Responses 1'!A1:CS125";
 
-let cachedToken:
+let cachedServiceAccountToken:
+  | {
+      accessToken: string;
+      expiresAt: number;
+    }
+  | undefined;
+
+let cachedOAuthToken:
   | {
       accessToken: string;
       expiresAt: number;
@@ -49,8 +56,11 @@ async function getServiceAccountAccessToken(): Promise<string | undefined> {
 
   const now = Math.floor(Date.now() / 1000);
 
-  if (cachedToken && cachedToken.expiresAt > now + 60) {
-    return cachedToken.accessToken;
+  if (
+    cachedServiceAccountToken &&
+    cachedServiceAccountToken.expiresAt > now + 60
+  ) {
+    return cachedServiceAccountToken.accessToken;
   }
 
   const header = {
@@ -96,12 +106,12 @@ async function getServiceAccountAccessToken(): Promise<string | undefined> {
     expires_in: number;
   };
 
-  cachedToken = {
+  cachedServiceAccountToken = {
     accessToken: token.access_token,
     expiresAt: now + token.expires_in,
   };
 
-  return cachedToken.accessToken;
+  return cachedServiceAccountToken.accessToken;
 }
 
 async function getOAuthAccessToken(): Promise<string | undefined> {
@@ -115,8 +125,8 @@ async function getOAuthAccessToken(): Promise<string | undefined> {
 
   const now = Math.floor(Date.now() / 1000);
 
-  if (cachedToken && cachedToken.expiresAt > now + 60) {
-    return cachedToken.accessToken;
+  if (cachedOAuthToken && cachedOAuthToken.expiresAt > now + 60) {
+    return cachedOAuthToken.accessToken;
   }
 
   const response = await fetch('https://oauth2.googleapis.com/token', {
@@ -141,12 +151,12 @@ async function getOAuthAccessToken(): Promise<string | undefined> {
     expires_in: number;
   };
 
-  cachedToken = {
+  cachedOAuthToken = {
     accessToken: token.access_token,
     expiresAt: now + token.expires_in,
   };
 
-  return cachedToken.accessToken;
+  return cachedOAuthToken.accessToken;
 }
 
 async function getGoogleAccessToken(): Promise<string | undefined> {

--- a/packages/backend/src/data-sources/google/GoogleAPI.ts
+++ b/packages/backend/src/data-sources/google/GoogleAPI.ts
@@ -1,45 +1,244 @@
-import { AugmentedRequest, RESTDataSource } from '@apollo/datasource-rest';
+import crypto from 'crypto';
 import { Question, User } from '../../models';
-import { getEnvVar } from '../../utils/env';
+import { getOptionalEnvVar } from '../../utils/env';
 import { getPoints } from './points';
 
-const GOOGLE_API_KEY = getEnvVar('GOOGLE_API_KEY');
-const GOOGLE_SHEETS_ID = '1e7SwesvqHvh0TGgVinoTVUr4ymoK6i8vmPmniQXK0AM';
-const GOOGLE_SHEETS_RANGE = 'A1:AY27';
+const GOOGLE_API_KEY = getOptionalEnvVar('GOOGLE_API_KEY');
+const GOOGLE_SERVICE_ACCOUNT_EMAIL = getOptionalEnvVar(
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL'
+);
+const GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY = getOptionalEnvVar(
+  'GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY'
+);
+const GOOGLE_OAUTH_CLIENT_ID = getOptionalEnvVar('GOOGLE_OAUTH_CLIENT_ID');
+const GOOGLE_OAUTH_CLIENT_SECRET = getOptionalEnvVar(
+  'GOOGLE_OAUTH_CLIENT_SECRET'
+);
+const GOOGLE_OAUTH_REFRESH_TOKEN = getOptionalEnvVar(
+  'GOOGLE_OAUTH_REFRESH_TOKEN'
+);
+const GOOGLE_SHEETS_ID =
+  getOptionalEnvVar('GOOGLE_SHEETS_ID') ||
+  '1hsMSMhqu4UTrPlToYrfxjFrIXmT2JaiVzzjXeUvbgpw';
+const GOOGLE_SHEETS_RANGE =
+  getOptionalEnvVar('GOOGLE_SHEETS_RANGE') || "'Form Responses 1'!A1:CS125";
 
-export class GoogleAPI extends RESTDataSource {
-  baseURL = 'https://sheets.googleapis.com';
+let cachedToken:
+  | {
+      accessToken: string;
+      expiresAt: number;
+    }
+  | undefined;
 
-  protected override willSendRequest(
-    _path: string,
-    request: AugmentedRequest
-  ): void {
-    request.params.set('key', GOOGLE_API_KEY);
+function normalizePrivateKey(privateKey: string): string {
+  return privateKey.replace(/\\n/g, '\n');
+}
+
+function base64Url(input: string): string {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+async function getServiceAccountAccessToken(): Promise<string | undefined> {
+  if (!GOOGLE_SERVICE_ACCOUNT_EMAIL || !GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY) {
+    return undefined;
   }
 
-  private async getGoogleSheetsData(): Promise<string[][]> {
-    const data = await this.get<{
-      values: string[][];
-    }>(`v4/spreadsheets/${GOOGLE_SHEETS_ID}/values/${GOOGLE_SHEETS_RANGE}`);
+  const now = Math.floor(Date.now() / 1000);
 
-    return data.values;
+  if (cachedToken && cachedToken.expiresAt > now + 60) {
+    return cachedToken.accessToken;
+  }
+
+  const header = {
+    alg: 'RS256',
+    typ: 'JWT',
+  };
+  const claimSet = {
+    iss: GOOGLE_SERVICE_ACCOUNT_EMAIL,
+    scope: 'https://www.googleapis.com/auth/spreadsheets.readonly',
+    aud: 'https://oauth2.googleapis.com/token',
+    exp: now + 3600,
+    iat: now,
+  };
+  const unsignedToken = `${base64Url(JSON.stringify(header))}.${base64Url(
+    JSON.stringify(claimSet)
+  )}`;
+  const signature = crypto
+    .createSign('RSA-SHA256')
+    .update(unsignedToken)
+    .sign(normalizePrivateKey(GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY), 'base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  const assertion = `${unsignedToken}.${signature}`;
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google service account auth failed: ${response.status}`);
+  }
+
+  const token = (await response.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+
+  cachedToken = {
+    accessToken: token.access_token,
+    expiresAt: now + token.expires_in,
+  };
+
+  return cachedToken.accessToken;
+}
+
+async function getOAuthAccessToken(): Promise<string | undefined> {
+  if (
+    !GOOGLE_OAUTH_CLIENT_ID ||
+    !GOOGLE_OAUTH_CLIENT_SECRET ||
+    !GOOGLE_OAUTH_REFRESH_TOKEN
+  ) {
+    return undefined;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (cachedToken && cachedToken.expiresAt > now + 60) {
+    return cachedToken.accessToken;
+  }
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      client_id: GOOGLE_OAUTH_CLIENT_ID,
+      client_secret: GOOGLE_OAUTH_CLIENT_SECRET,
+      refresh_token: GOOGLE_OAUTH_REFRESH_TOKEN,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google OAuth refresh failed: ${response.status}`);
+  }
+
+  const token = (await response.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+
+  cachedToken = {
+    accessToken: token.access_token,
+    expiresAt: now + token.expires_in,
+  };
+
+  return cachedToken.accessToken;
+}
+
+async function getGoogleAccessToken(): Promise<string | undefined> {
+  return (await getServiceAccountAccessToken()) || getOAuthAccessToken();
+}
+
+function normalizeMarker(value: string | undefined): string {
+  return (value || '').trim().toLowerCase();
+}
+
+function isBlueprintRow(row: string[]): boolean {
+  return row.slice(0, 3).some((cell) => {
+    const marker = normalizeMarker(cell);
+    return marker === 'fasit' || marker === 'blueprint';
+  });
+}
+
+function splitRowsAndBlueprint(rows: string[][]): {
+  rows: string[][];
+  blueprints: string[];
+} {
+  for (let index = rows.length - 1; index >= 0; index = index - 1) {
+    if (isBlueprintRow(rows[index])) {
+      return {
+        rows: [...rows.slice(0, index), ...rows.slice(index + 1)],
+        blueprints: rows[index],
+      };
+    }
+  }
+
+  return {
+    rows,
+    blueprints: [],
+  };
+}
+
+export class GoogleAPI {
+  private async getGoogleSheetsData(): Promise<string[][]> {
+    const searchParams = new URLSearchParams();
+    const accessToken = await getGoogleAccessToken();
+
+    if (accessToken) {
+      searchParams.set('valueRenderOption', 'FORMATTED_VALUE');
+    } else if (GOOGLE_API_KEY) {
+      searchParams.set('key', GOOGLE_API_KEY);
+      searchParams.set('valueRenderOption', 'FORMATTED_VALUE');
+    } else {
+      throw new Error(
+        'GOOGLE_API_KEY, Google service account credentials, or Google OAuth refresh credentials are required'
+      );
+    }
+
+    const response = await fetch(
+      `https://sheets.googleapis.com/v4/spreadsheets/${GOOGLE_SHEETS_ID}/values/${encodeURIComponent(
+        GOOGLE_SHEETS_RANGE
+      )}?${searchParams.toString()}`,
+      {
+        headers: accessToken
+          ? {
+              authorization: `Bearer ${accessToken}`,
+            }
+          : undefined,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Google Sheets API failed: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      values: string[][];
+    };
+
+    return data.values || [];
   }
 
   public async getUsers(): Promise<User[] | undefined> {
     const googleSheetsData = await this.getGoogleSheetsData();
 
-    const [headers, ...users] = googleSheetsData;
+    const [headers = [], ...sheetRows] = googleSheetsData;
 
-    const blueprints = users.pop() || [];
+    const { rows, blueprints } = splitRowsAndBlueprint(sheetRows);
 
-    return users
+    return rows
+      .filter((user) => user.some((cell) => cell.trim() !== ''))
       .map((user, userId) => {
-        const [timestamp, email, name, ...rest] = user;
+        const [timestamp = '', email = '', name = '', ...rest] = user;
 
         let points = 0;
 
-        const questions = rest.map((answer, index) => {
-          const question = headers[index + 3];
+        const questions = headers.slice(3).map((question, index) => {
+          const answer = rest[index] || '';
           const blueprint = blueprints[index + 3];
 
           const questionPoints = getPoints(question, answer, blueprint);
@@ -59,7 +258,7 @@ export class GoogleAPI extends RESTDataSource {
 
         return new User({
           id: `world-cup:user:${userId + 1}`,
-          name,
+          name: name || email || `Deltaker ${userId + 1}`,
           email,
           timestamp,
           points,

--- a/packages/backend/src/data-sources/google/points.test.ts
+++ b/packages/backend/src/data-sources/google/points.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest';
+import { getPoints } from './points';
+
+describe('getPoints', () => {
+  test('scores group-stage matches from the 2026 form as winner plus exact result', () => {
+    expect(getPoints('Mexico - Sør-Afrika', '2:1', '2-1')).toEqual({
+      points: 2,
+      maxPoints: 2,
+    });
+    expect(getPoints('Mexico - Sør-Afrika', '2–1', '2-0')).toEqual({
+      points: 1,
+      maxPoints: 2,
+    });
+    expect(getPoints('Mexico - Sør-Afrika', '4-«', '2-0')).toEqual({
+      points: 0,
+      maxPoints: 2,
+    });
+  });
+
+  test('scores 2026 knockout team picks using the form point values', () => {
+    expect(
+      getPoints(
+        'Hvem går videre til 16-delsfinaler? Alle lag topp to og 8 av 12 lag på tredjeplass går videre til 16-delsfinaler.',
+        'Argentina, Norge, Frankrike',
+        'Argentina, Brasil, Frankrike'
+      )
+    ).toEqual({
+      points: 2,
+      maxPoints: 3,
+    });
+    expect(
+      getPoints(
+        'Hvilke lag finner vi i 8-delsfinalene?',
+        'Argentina, Norge',
+        'Argentina, Brasil'
+      )
+    ).toEqual({
+      points: 2,
+      maxPoints: 4,
+    });
+    expect(
+      getPoints(
+        'Hvilke lag finner vi i kvartfinalene?',
+        'Argentina, Norge',
+        'Argentina, Brasil'
+      )
+    ).toEqual({
+      points: 3,
+      maxPoints: 6,
+    });
+    expect(
+      getPoints(
+        'Hvilke lag finner vi i semifinalene?',
+        'Frankrike, Norge',
+        'Frankrike, Spania'
+      )
+    ).toEqual({
+      points: 5,
+      maxPoints: 10,
+    });
+    expect(
+      getPoints(
+        'Hvilke to lag finner vi i finalen? ',
+        'Frankrike, Spania',
+        'Frankrike, Spania'
+      )
+    ).toEqual({
+      points: 14,
+      maxPoints: 14,
+    });
+  });
+
+  test('scores 2026 specials with normalization for common user input variants', () => {
+    expect(
+      getPoints('Toppscorer etter gruppespill', 'Haaland ', 'Håland')
+    ).toEqual({
+      points: 3,
+      maxPoints: 3,
+    });
+    expect(
+      getPoints('Vinner\nRiktig: 10 poeng', 'frankrike', 'Frankrike')
+    ).toEqual({
+      points: 10,
+      maxPoints: 10,
+    });
+    expect(
+      getPoints(
+        'Beste unge spiller (FIFA Young Player of the Tournament). Må være under 21 år ved starten av kalenderåret 2026.\nRiktig: 2 poeng',
+        'Lamine Yamal.',
+        'Lamine Yamal'
+      )
+    ).toEqual({
+      points: 2,
+      maxPoints: 2,
+    });
+    expect(
+      getPoints('Hvem skårer Norges første mål?', 'Haaland ', 'Håland')
+    ).toEqual({
+      points: 1,
+      maxPoints: 1,
+    });
+  });
+});

--- a/packages/backend/src/data-sources/google/points.ts
+++ b/packages/backend/src/data-sources/google/points.ts
@@ -1,31 +1,121 @@
 const POINTS_MATCH_WINNER = 1;
 const POINTS_MATCH_RESULT = 1;
 
-const POINTS: { [question: string]: number } = {
-  'Toppscorer etter gruppespill': 3,
-  'Assistkonge etter gruppespill': 3,
-  'Råtasslag etter gruppespill': 3,
-  'Hvem går videre til 8-delsfinaler? Alle lag topp to og 4 av 6 lag på tredjeplass går videre til 8-delsfinaler.': 1,
-  Kvartfinalelag: 3,
-  Semifinalelag: 4,
-  Finalelag: 6,
-  Vinner: 10,
-  'Toppscorer (Golden Boot)': 5,
-  Assistkonge: 5,
-  'Beste spiller (UEFA Player of the Tournament)': 5,
-  'Beste unge spiller (UEFA Young Player of the Tournament). Må være under 21 år ved starten av kalenderåret 2024.': 2,
-};
+function normalizeText(value: string | undefined): string {
+  return (value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[æ]/gi, 'ae')
+    .replace(/[ø]/gi, 'o')
+    .replace(/[å]/gi, 'a')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[.。]+$/g, '')
+    .toLowerCase()
+    .replace(/aa/g, 'a');
+}
 
-function getWinner(score: string): number {
-  const s = score.split('-');
-  const homeScore = s[0];
-  const awayScore = s[1];
+function normalizeQuestion(question: string): string {
+  return normalizeText(question.replace(/\n/g, ' '));
+}
 
-  if (homeScore > awayScore) {
+function getPointsPerCorrectAnswer(question: string): number | undefined {
+  const normalizedQuestion = normalizeQuestion(question);
+
+  if (
+    normalizedQuestion === 'toppscorer etter gruppespill' ||
+    normalizedQuestion === 'assistkonge etter gruppespill' ||
+    normalizedQuestion === 'ratasslag etter gruppespill'
+  ) {
+    return 3;
+  }
+
+  if (normalizedQuestion.includes('hvem gar videre til 16-delsfinaler')) {
     return 1;
-  } else if (homeScore < awayScore) {
+  }
+
+  if (normalizedQuestion.includes('hvilke lag finner vi i 8-delsfinalene')) {
+    return 2;
+  }
+
+  if (normalizedQuestion.includes('hvilke lag finner vi i kvartfinalene')) {
+    return 3;
+  }
+
+  if (normalizedQuestion.includes('hvilke lag finner vi i semifinalene')) {
+    return 5;
+  }
+
+  if (normalizedQuestion.includes('hvilke to lag finner vi i finalen')) {
+    return 7;
+  }
+
+  if (normalizedQuestion.startsWith('vinner')) {
+    return 10;
+  }
+
+  if (
+    normalizedQuestion.startsWith('toppscorer (golden boot)') ||
+    normalizedQuestion.startsWith('assistkonge') ||
+    normalizedQuestion.startsWith('beste spiller')
+  ) {
+    return 5;
+  }
+
+  if (normalizedQuestion.startsWith('beste unge spiller')) {
+    return 2;
+  }
+
+  if (
+    normalizedQuestion === 'hvem skarer norges forste mal?' ||
+    normalizedQuestion ===
+      'hvor mange mal skarer norge totalt? (straffekonk ikke tellende)' ||
+    normalizedQuestion === 'hvem far norges forste gule kort?'
+  ) {
+    return 1;
+  }
+
+  return undefined;
+}
+
+function splitAnswerList(value: string): string[] {
+  return value
+    .split(/[,;]|\.\s+/g)
+    .map(normalizeText)
+    .filter(Boolean);
+}
+
+function parseScore(score: string):
+  | {
+      home: number;
+      away: number;
+    }
+  | undefined {
+  const normalizedScore = score
+    .trim()
+    .replace(/[–—]/g, '-')
+    .replace(/:/g, '-')
+    .replace(/\s+/g, '');
+  const match = normalizedScore.match(/^(\d+)-(\d+)\.?$/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    home: Number(match[1]),
+    away: Number(match[2]),
+  };
+}
+
+function getWinner(score: { home: number; away: number }): number {
+  if (score.home > score.away) {
+    return 1;
+  } else if (score.home < score.away) {
     return -1;
   }
+
   return 0;
 }
 
@@ -43,32 +133,42 @@ export function getPoints(
     return undefined;
   }
 
-  let points = 0;
+  const pointsPerCorrectAnswer = getPointsPerCorrectAnswer(question);
 
-  if (POINTS[question]) {
-    const answers = answer.split(', ');
-    const blueprints = new Set(blueprint.split('. '));
+  if (pointsPerCorrectAnswer) {
+    const answers = new Set(splitAnswerList(answer));
+    const blueprints = new Set(splitAnswerList(blueprint));
+    let points = 0;
 
     answers.forEach((a) => {
       if (blueprints.has(a)) {
-        points = points + POINTS[question];
+        points = points + pointsPerCorrectAnswer;
       }
     });
 
     return {
       points,
-      maxPoints: POINTS[question] * blueprints.size,
+      maxPoints: pointsPerCorrectAnswer * blueprints.size,
     };
   }
 
-  if (answer === blueprint) {
+  const answerScore = parseScore(answer);
+  const blueprintScore = parseScore(blueprint);
+
+  if (!blueprintScore) {
+    return undefined;
+  }
+
+  let points = 0;
+
+  if (
+    answerScore?.home === blueprintScore.home &&
+    answerScore.away === blueprintScore.away
+  ) {
     points = POINTS_MATCH_RESULT;
   }
 
-  const playerWinner = getWinner(answer);
-  const winner = getWinner(blueprint);
-
-  if (playerWinner === winner) {
+  if (answerScore && getWinner(answerScore) === getWinner(blueprintScore)) {
     points = points + POINTS_MATCH_WINNER;
   }
 

--- a/packages/backend/src/data-sources/google/points.ts
+++ b/packages/backend/src/data-sources/google/points.ts
@@ -162,7 +162,8 @@ export function getPoints(
   let points = 0;
 
   if (
-    answerScore?.home === blueprintScore.home &&
+    answerScore &&
+    answerScore.home === blueprintScore.home &&
     answerScore.away === blueprintScore.away
   ) {
     points = POINTS_MATCH_RESULT;

--- a/packages/backend/src/utils/env.ts
+++ b/packages/backend/src/utils/env.ts
@@ -1,7 +1,9 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-function getOptionalEnvVar(environmentVariable: string): string | undefined {
+export function getOptionalEnvVar(
+  environmentVariable: string
+): string | undefined {
   return process.env[environmentVariable];
 }
 

--- a/packages/cdk/src/cdk-stack.ts
+++ b/packages/cdk/src/cdk-stack.ts
@@ -8,7 +8,7 @@ import {
 } from 'aws-cdk-lib/aws-certificatemanager';
 import { Cors, LambdaRestApi } from 'aws-cdk-lib/aws-apigateway';
 import path from 'path';
-import { getEnvVar } from './env';
+import { getEnvVar, getOptionalEnvVar } from './env';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { ApiGateway, CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import {
@@ -23,7 +23,35 @@ const DOMAIN_HOSTED_ZONE = getEnvVar('DOMAIN_HOSTED_ZONE');
 const DOMAIN_GRAPHQL_SERVER = getEnvVar('DOMAIN_GRAPHQL_SERVER');
 const CLOUDFRONT_CERTIFICATE_ARN = getEnvVar('CLOUDFRONT_CERTIFICATE_ARN');
 
-const GOOGLE_API_KEY = getEnvVar('GOOGLE_API_KEY');
+const GOOGLE_API_KEY = getOptionalEnvVar('GOOGLE_API_KEY');
+const GOOGLE_SERVICE_ACCOUNT_EMAIL = getOptionalEnvVar(
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL'
+);
+const GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY = getOptionalEnvVar(
+  'GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY'
+);
+const GOOGLE_OAUTH_CLIENT_ID = getOptionalEnvVar('GOOGLE_OAUTH_CLIENT_ID');
+const GOOGLE_OAUTH_CLIENT_SECRET = getOptionalEnvVar(
+  'GOOGLE_OAUTH_CLIENT_SECRET'
+);
+const GOOGLE_OAUTH_REFRESH_TOKEN = getOptionalEnvVar(
+  'GOOGLE_OAUTH_REFRESH_TOKEN'
+);
+const GOOGLE_SHEETS_ID = getOptionalEnvVar('GOOGLE_SHEETS_ID');
+const GOOGLE_SHEETS_RANGE = getOptionalEnvVar('GOOGLE_SHEETS_RANGE');
+
+const googleEnvironment = Object.fromEntries(
+  Object.entries({
+    GOOGLE_API_KEY,
+    GOOGLE_SERVICE_ACCOUNT_EMAIL,
+    GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY,
+    GOOGLE_OAUTH_CLIENT_ID,
+    GOOGLE_OAUTH_CLIENT_SECRET,
+    GOOGLE_OAUTH_REFRESH_TOKEN,
+    GOOGLE_SHEETS_ID,
+    GOOGLE_SHEETS_RANGE,
+  }).filter((entry): entry is [string, string] => Boolean(entry[1]))
+);
 
 export class WorldCupStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
@@ -40,7 +68,7 @@ export class WorldCupStack extends Stack {
         memorySize: 1024,
         environment: {
           NODE_ENV: 'production',
-          GOOGLE_API_KEY,
+          ...googleEnvironment,
         },
       }
     );

--- a/packages/cdk/src/env.ts
+++ b/packages/cdk/src/env.ts
@@ -10,3 +10,7 @@ export function getEnvVar(key: string): string {
 
   return envVar;
 }
+
+export function getOptionalEnvVar(key: string): string | undefined {
+  return process.env[key];
+}

--- a/packages/frontend/src/pages/Users/Users.tsx
+++ b/packages/frontend/src/pages/Users/Users.tsx
@@ -12,16 +12,21 @@ import { Question, useGetUsersQuery } from '../../generated/queries';
 import { ErrorPage } from '../ErrorPage';
 
 function getWidth(question: string): number {
-  switch (question) {
-    case 'Hvem går videre til 8-delsfinaler? Alle lag topp to og 4 av 6 lag på tredjeplass går videre til 8-delsfinaler.':
-      return 850;
-    case 'Kvartfinalelag':
-      return 450;
-    case 'Semifinalelag':
-      return 250;
-    default:
-      return 200;
+  if (
+    question.includes('Hvem går videre til 16-delsfinaler') ||
+    question.includes('Hvilke lag finner vi i 8-delsfinalene?')
+  ) {
+    return 850;
+  } else if (question.includes('kvartfinalene')) {
+    return 450;
+  } else if (
+    question.includes('semifinalene') ||
+    question.includes('finalen')
+  ) {
+    return 320;
   }
+
+  return 200;
 }
 
 export function Users() {


### PR DESCRIPTION
## Summary
- migrate the backend defaults to the VM-tipping 2026 response sheet
- add private Google Sheet access for AWS Lambda through a dedicated service-account credential path
- update 2026 scoring rules from the new form and harden score/text normalization for common bad inputs
- stop treating the last response row as fasit unless it is explicitly marked
- add backend tests for the critical scoring paths

## AWS / Google setup
- created `world-cup-sheets-reader@gen-lang-client-0247180398.iam.gserviceaccount.com`
- granted that service account reader access to the 2026 response spreadsheet
- stored verified GitHub secrets `GOOGLE_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`

## Verification
- `npm test`
- `npm run build`
- verified the app `GoogleAPI` service-account path can read the private sheet and returns 24 users
