### PR TITLE
[codex] Add CORS headers to GraphQL responses

### DIFF
--- a/packages/backend/src/server/server.test.ts
+++ b/packages/backend/src/server/server.test.ts
@@ -1,0 +1,30 @@
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { describe, expect, test } from 'vitest';
+import { handler } from './server';
+
+describe('GraphQL Lambda handler', () => {
+  test('adds CORS headers to GraphQL responses', async () => {
+    const event = {
+      body: JSON.stringify({ query: '{ __typename }' }),
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://tipping.aasan.dev',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded: false,
+      multiValueQueryStringParameters: {},
+    } as unknown as APIGatewayProxyEvent;
+
+    const response = await handler(event, {} as Context, () => undefined);
+
+    if (!response) {
+      throw new Error('Expected Lambda response');
+    }
+
+    expect(response.headers).toMatchObject({
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Origin': 'https://tipping.aasan.dev',
+      Vary: 'Origin',
+    });
+  });
+});

--- a/packages/backend/src/server/server.ts
+++ b/packages/backend/src/server/server.ts
@@ -2,10 +2,26 @@ import { ApolloServer } from '@apollo/server';
 import responseCachePlugin from '@apollo/server-plugin-response-cache';
 import {
   handlers,
+  middleware,
   startServerAndCreateLambdaHandler,
 } from '@as-integrations/aws-lambda';
 import { IExecutableSchemaDefinition } from '@graphql-tools/schema';
 import { resolvers, typeDefs } from '../schema';
+
+const ALLOWED_ORIGIN = 'https://tipping.aasan.dev';
+const requestHandler = handlers.createAPIGatewayProxyEventRequestHandler();
+
+const corsMiddleware: middleware.MiddlewareFn<typeof requestHandler> = () => {
+  return Promise.resolve((result) => {
+    result.headers = {
+      ...result.headers,
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+      Vary: 'Origin',
+    };
+    return Promise.resolve();
+  });
+};
 
 const server = new ApolloServer({
   typeDefs,
@@ -15,5 +31,8 @@ const server = new ApolloServer({
 
 export const handler = startServerAndCreateLambdaHandler(
   server,
-  handlers.createAPIGatewayProxyEventRequestHandler()
+  requestHandler,
+  {
+    middleware: [corsMiddleware],
+  }
 );


### PR DESCRIPTION
## What changed

- Added Apollo Lambda result middleware that attaches CORS headers to actual GraphQL responses.
- Added a backend regression test that invokes the exported Lambda handler and asserts the response contains the expected CORS headers.

## Root cause

API Gateway was configured for CORS preflight, so `OPTIONS` returned `Access-Control-Allow-Origin`, but the Lambda `POST` result returned by Apollo did not include CORS headers. Browsers therefore rejected the real GraphQL response after the frontend Apollo Client fix started making valid requests.

## Validation

- `npm test`
- `npm run build`
- Confirmed current production `OPTIONS` has CORS headers while production `POST` lacks `Access-Control-Allow-Origin` before this fix.