### PR TITLE
Fix production Google Sheets fetch

### DIFF
--- a/packages/backend/src/data-sources/google/GoogleAPI.test.ts
+++ b/packages/backend/src/data-sources/google/GoogleAPI.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { buildUsersFromGoogleSheetsData } from './GoogleAPI';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  globalThis.fetch = originalFetch;
+});
 
 describe('buildUsersFromGoogleSheetsData', () => {
   test('adds ranks, possible points and question statuses', () => {
@@ -50,5 +58,40 @@ describe('buildUsersFromGoogleSheetsData', () => {
       { name: 'Bjørn', rank: 1 },
       { name: 'Carla', rank: 3 },
     ]);
+  });
+
+  test('fetches Google Sheets in production when an API key is configured', async () => {
+    vi.resetModules();
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('GOOGLE_API_KEY', 'test-api-key');
+    vi.stubEnv('GOOGLE_SHEETS_ID', 'sheet-id');
+    vi.stubEnv('GOOGLE_SHEETS_RANGE', "'Form Responses 1'!A1:D4");
+
+    const fetchMock = vi.fn<typeof fetch>(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            values: [
+              ['Timestamp', 'Email', 'Name', 'Mexico - Sør-Afrika'],
+              ['2026-01-01', 'a@example.com', 'Anna', '2-1'],
+              ['fasit', '', '', '2-1'],
+            ],
+          }),
+        ok: true,
+      } as Response)
+    );
+    globalThis.fetch = fetchMock;
+
+    const { GoogleAPI } = await import('./GoogleAPI');
+    const users = await new GoogleAPI().getUsers();
+
+    expect(users?.[0].name).toBe('Anna');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const requestUrl = fetchMock.mock.calls[0][0];
+    expect(requestUrl).toBeTypeOf('string');
+    if (typeof requestUrl !== 'string') {
+      throw new Error('Expected Google Sheets request URL to be a string');
+    }
+    expect(requestUrl).toContain('key=test-api-key');
   });
 });

--- a/packages/backend/src/data-sources/google/GoogleAPI.ts
+++ b/packages/backend/src/data-sources/google/GoogleAPI.ts
@@ -368,12 +368,15 @@ export class GoogleAPI {
   private async getGoogleSheetsData(): Promise<string[][]> {
     const searchParams = new URLSearchParams();
     const accessToken = await getGoogleAccessToken();
+    let shouldFetchGoogleSheets = false;
 
     if (accessToken) {
       searchParams.set('valueRenderOption', 'FORMATTED_VALUE');
+      shouldFetchGoogleSheets = true;
     } else if (GOOGLE_API_KEY) {
       searchParams.set('key', GOOGLE_API_KEY);
       searchParams.set('valueRenderOption', 'FORMATTED_VALUE');
+      shouldFetchGoogleSheets = true;
     } else if (USE_GWS_DEV_SOURCE) {
       try {
         console.warn('Using gws CLI to read Google Sheets in development');
@@ -392,10 +395,12 @@ export class GoogleAPI {
       }
     }
 
-    if (USE_DEV_SHEET_FALLBACK) {
-      console.warn('Using development Google Sheets fixture');
-      return DEV_GOOGLE_SHEETS_DATA;
-    } else {
+    if (!shouldFetchGoogleSheets) {
+      if (USE_DEV_SHEET_FALLBACK) {
+        console.warn('Using development Google Sheets fixture');
+        return DEV_GOOGLE_SHEETS_DATA;
+      }
+
       throw new Error(
         'GOOGLE_API_KEY, Google service account credentials, or Google OAuth refresh credentials are required'
       );


### PR DESCRIPTION
## Summary
- fix Google Sheets source selection so production fetches when an API key or access token is configured
- keep dev fixture fallback limited to cases where no real Sheets source is available
- add a regression test for production + GOOGLE_API_KEY

## Verification
- npm test
- npm run build

## Context
Production was showing: GOOGLE_API_KEY, Google service account credentials, or Google OAuth refresh credentials are required. The merged code set auth query params but then still reached the no-source throw before performing the fetch.