### PR TITLE
Fix production fetch regression test env

### DIFF
--- a/packages/backend/src/data-sources/google/GoogleAPI.test.ts
+++ b/packages/backend/src/data-sources/google/GoogleAPI.test.ts
@@ -64,6 +64,11 @@ describe('buildUsersFromGoogleSheetsData', () => {
     vi.resetModules();
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('GOOGLE_API_KEY', 'test-api-key');
+    vi.stubEnv('GOOGLE_SERVICE_ACCOUNT_EMAIL', '');
+    vi.stubEnv('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY', '');
+    vi.stubEnv('GOOGLE_OAUTH_CLIENT_ID', '');
+    vi.stubEnv('GOOGLE_OAUTH_CLIENT_SECRET', '');
+    vi.stubEnv('GOOGLE_OAUTH_REFRESH_TOKEN', '');
     vi.stubEnv('GOOGLE_SHEETS_ID', 'sheet-id');
     vi.stubEnv('GOOGLE_SHEETS_RANGE', "'Form Responses 1'!A1:D4");
 


### PR DESCRIPTION
## Summary
- isolate the production API-key regression test from deploy-time service account/OAuth secrets
- keeps the previous production Google Sheets fetch fix intact

## Verification
- npm test
- npm run build