### PR TITLE
Add question search to results page

### DIFF
--- a/packages/frontend/src/pages/Users/Users.test.tsx
+++ b/packages/frontend/src/pages/Users/Users.test.tsx
@@ -414,6 +414,26 @@ describe('Users', () => {
     ]);
   });
 
+  test('filters question columns by match or question search text', async () => {
+    render(<Users />);
+
+    expect(
+      latestDataGridProps.current?.columns.map((column) => column.field)
+    ).toContain('Mexico - Sør-Afrika');
+    expect(
+      latestDataGridProps.current?.columns.map((column) => column.field)
+    ).toContain('Toppscorer etter gruppespill');
+
+    await userEvent.type(screen.getByLabelText('Søk kamp/spørsmål'), 'sor');
+
+    expect(
+      latestDataGridProps.current?.columns.map((column) => column.field)
+    ).toContain('Mexico - Sør-Afrika');
+    expect(
+      latestDataGridProps.current?.columns.map((column) => column.field)
+    ).not.toContain('Toppscorer etter gruppespill');
+  });
+
   test('toggles question cells between answers and points', async () => {
     render(<Users />);
 

--- a/packages/frontend/src/pages/Users/Users.tsx
+++ b/packages/frontend/src/pages/Users/Users.tsx
@@ -32,6 +32,18 @@ import { QuestionSummary, getQuestionSummaries } from './questionSummaries';
 
 type QuestionFilter = 'all' | 'scored' | 'unscored';
 
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[æ]/gi, 'ae')
+    .replace(/[ø]/gi, 'o')
+    .replace(/[å]/gi, 'a')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
 const CATEGORY_LABELS: Record<string, string> = {
   MATCHES: 'Kamper',
   KNOCKOUT: 'Sluttspill',
@@ -354,6 +366,7 @@ export function Users() {
     notifyOnNetworkStatusChange: true,
   });
   const [search, setSearch] = useState('');
+  const [questionSearch, setQuestionSearch] = useState('');
   const [questionFilter, setQuestionFilter] = useState<QuestionFilter>('all');
   const [showAnswerText, setShowAnswerText] = useState(true);
   const [selectedUserId, setSelectedUserId] = useState<string | undefined>();
@@ -373,18 +386,29 @@ export function Users() {
   ).length;
   const remainingPossiblePoints = users[0]?.remaining_possible_points || 0;
   const filteredUsers = useMemo(() => {
-    const normalizedSearch = search.trim().toLowerCase();
+    const normalizedSearch = normalizeSearchText(search);
 
     if (!normalizedSearch) {
       return users;
     }
 
     return users.filter((user) =>
-      user.name.toLowerCase().includes(normalizedSearch)
+      normalizeSearchText(user.name).includes(normalizedSearch)
     );
   }, [search, users]);
   const visibleQuestions = useMemo(() => {
+    const normalizedQuestionSearch = normalizeSearchText(questionSearch);
+
     return questions.filter((question) => {
+      if (
+        normalizedQuestionSearch &&
+        !normalizeSearchText(question.question).includes(
+          normalizedQuestionSearch
+        )
+      ) {
+        return false;
+      }
+
       if (questionFilter === 'scored') {
         return question.status !== 'UNSCORED';
       }
@@ -395,7 +419,7 @@ export function Users() {
 
       return true;
     });
-  }, [questionFilter, questions]);
+  }, [questionFilter, questionSearch, questions]);
 
   if (error) {
     console.error(error);
@@ -533,7 +557,14 @@ export function Users() {
               sx={{ minWidth: { md: 260 } }}
             />
             <TextField
-              label="Spørsmål"
+              label="Søk kamp/spørsmål"
+              value={questionSearch}
+              onChange={(event) => setQuestionSearch(event.target.value)}
+              size="small"
+              sx={{ minWidth: { md: 260 } }}
+            />
+            <TextField
+              label="Status"
               select
               value={questionFilter}
               onChange={(event) =>


### PR DESCRIPTION
### Motivation
- Provide the ability to search for a specific match or question on the results page so users can filter visible question columns by match/question text. 
- Make searches more robust by normalizing Norwegian characters and diacritics so name and question matching is case- and accent-insensitive.

### Description
- Added `normalizeSearchText` and switched participant name filtering to use it so name searches tolerate diacritics and casing (`packages/frontend/src/pages/Users/Users.tsx`).
- Added a `questionSearch` state and a new `Søk kamp/spørsmål` input that narrows `visibleQuestions` by normalized match/question text while preserving the existing status filter (`questionFilter`).
- Updated the `visibleQuestions` memo to combine the new question text filter with the existing scored/unscored status filter and to include `questionSearch` in its dependency list.
- Added a frontend unit test that asserts question column filtering by match/question search text (`packages/frontend/src/pages/Users/Users.test.tsx`).

### Testing
- Ran the frontend unit tests with `npm run test --workspace world-cup-frontend -- Users.test.tsx` and all tests passed (6 tests).
- Ran the full project typecheck with `npm run typecheck` and it passed.
- Ran linting with `npm run eslint` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa48f9d888333a4e080fde217c7db)